### PR TITLE
Allow Safari / WebKit to have SharedBuffer too

### DIFF
--- a/coi-serviceworker.js
+++ b/coi-serviceworker.js
@@ -43,6 +43,9 @@ if (typeof window === 'undefined') {
                     newHeaders.set("Cross-Origin-Embedder-Policy",
                         coepCredentialless ? "credentialless" : "require-corp"
                     );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
                     newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
 
                     return new Response(response.body, {
@@ -61,7 +64,7 @@ if (typeof window === 'undefined') {
         const coi = {
             shouldRegister: () => true,
             shouldDeregister: () => false,
-            coepCredentialless: () => false,
+            coepCredentialless: () => !(window.chrome || window.netscape),
             doReload: () => window.location.reload(),
             quiet: false,
             ...window.coi


### PR DESCRIPTION
This MR enables CORP implicitly for non Chrome/Firefox based browsers and, when that's the case, it also set the CORP policy.

Tested [via coincident GitHub pages](https://webreflection.github.io/coincident/test/hyperhtml.html) successfully on both GNOME Web and Epiphany TP.